### PR TITLE
Removes game connection msgs; fix flib score screen

### DIFF
--- a/TaskList.md
+++ b/TaskList.md
@@ -1,8 +1,9 @@
 # Farsketched Implementation Task List
 
 ## On Deck
-- [ ] make scoring screen last longer on the leaderboard + include names
+- [ ] be able to go back to choose a game screen
 - [x?] client phone slow down (memory leak? reprocessing messages?)
+- [x] on reconnecting a client should get the whole game state and moved to the appropriate stage (hypothesis: the call to requestFullState() is happening before the client is connected) (this seems like it works but appeared to be a bug because of how laggy the client phone slow down issue was)
 - [ ] Add a fixture which makes the current player equal to the active player so we can verify what it looks like during guessing stage
 - [ ] do we want to put the gameconfig on gamestate? (mutating it outside the reducer feels wrong, but we may want the config on the client e.g. for showing the instructions to players in flibbertigibbet)
 - [ ] allow host to continue from game over stage (or maybe roll credits?)

--- a/src/ClientApp.tsx
+++ b/src/ClientApp.tsx
@@ -7,7 +7,7 @@ import { AudioProvider } from './contexts/AudioProvider';
 import { ThemeProvider, createTheme, responsiveFontSizes } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import { Game } from '@/types/games';
-import { Box } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 
 export const clientTheme = responsiveFontSizes(createTheme({
   typography: {
@@ -43,6 +43,90 @@ export const clientTheme = responsiveFontSizes(createTheme({
     },
   },
 }));
+
+// Fun background component with floating emojis
+function FunBackground() {
+  const [emojis, setEmojis] = useState<Array<{id: number, emoji: string, x: number, y: number, scale: number, opacity: number}>>([]);
+  
+  // Array of fun emojis
+  const emojiOptions = ['🎮', '🎲', '🎯', '🎨', '🎭', '🎪', '🎡', '🎢', '🎠', '🎪', '🎯', '🎲', '🎮', '🎨', '🎭'];
+  
+  useEffect(() => {
+    // Function to create a new random emoji
+    const createEmoji = () => {
+      return {
+        id: Math.random(),
+        emoji: emojiOptions[Math.floor(Math.random() * emojiOptions.length)],
+        x: Math.random() * 100, // Random position from 0-100% of screen width
+        y: Math.random() * 100, // Random position from 0-100% of screen height
+        scale: 1 + Math.random() * 2, // Random scale between 1 and 3
+        opacity: 0.2 + Math.random() * 0.3 // Random opacity between 0.2 and 0.5
+      };
+    };
+    
+    // Add a new emoji every 800ms
+    const intervalId = setInterval(() => {
+      setEmojis((current) => [...current, createEmoji()]);
+    }, 800);
+    
+    // Remove emojis after they fade out
+    const fadeIntervalId = setInterval(() => {
+      setEmojis((current) => 
+        current.map((emoji) => 
+          emoji.opacity > 0 ? { ...emoji, opacity: emoji.opacity - 0.02 } : emoji
+        ).filter((emoji) => emoji.opacity > 0)
+      );
+    }, 50);
+    
+    return () => {
+      clearInterval(intervalId);
+      clearInterval(fadeIntervalId);
+    };
+  }, []);
+  
+  return (
+    <Box
+      sx={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        width: '100%',
+        height: '100%',
+        pointerEvents: 'none', // Make sure it doesn't interfere with clicks
+        zIndex: 0,
+        overflow: 'hidden'
+      }}
+    >
+      {emojis.map((emoji) => (
+        <Box
+          key={emoji.id}
+          sx={{
+            position: 'absolute',
+            left: `${emoji.x}%`,
+            top: `${emoji.y}%`,
+            fontSize: `${emoji.scale}rem`,
+            opacity: emoji.opacity,
+            transition: 'opacity 2s ease-out, transform 0.5s ease-out',
+            transform: `scale(${emoji.opacity * 1.5})`,
+            animation: 'float 3s ease-in-out infinite',
+          }}
+        >
+          {emoji.emoji}
+        </Box>
+      ))}
+      <style>{`
+        @keyframes float {
+          0%, 100% {
+            transform: translateY(0) rotate(0deg);
+          }
+          50% {
+            transform: translateY(-20px) rotate(10deg);
+          }
+        }
+      `}</style>
+    </Box>
+  );
+}
 
 function ClientContent() {
   const { isConnected, setHostPeerId, connectToHost, peerId } = usePeer();
@@ -112,10 +196,82 @@ function ClientContent() {
           selectedGame ? (
             renderGameComponent(selectedGame)
           ) : (
-            <div>No game selected</div>
+            <Box
+              sx={{
+                flex: 1,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                background: 'linear-gradient(135deg, rgba(0,188,212,0.2) 0%, rgba(255,64,129,0.2) 50%, rgba(0,188,212,0.2) 100%)',
+                position: 'relative',
+                overflow: 'hidden',
+                '&::before': {
+                  content: '""',
+                  position: 'absolute',
+                  top: 0,
+                  left: 0,
+                  right: 0,
+                  bottom: 0,
+                  background: 'radial-gradient(circle at 50% 50%, rgba(255,255,255,0.9) 0%, rgba(255,255,255,0.6) 100%)',
+                  zIndex: 0
+                }
+              }}
+            >
+              <FunBackground />
+              <Typography
+                variant="h4"
+                sx={{
+                  fontWeight: 600,
+                  color: 'text.primary',
+                  textAlign: 'center',
+                  position: 'relative',
+                  zIndex: 1,
+                  px: 2,
+                  textShadow: '0 2px 4px rgba(0,0,0,0.1)'
+                }}
+              >
+                No game selected
+              </Typography>
+            </Box>
           )
         ) : (
-          <div className="connection-status">Connecting to host...</div>
+          <Box
+            sx={{
+              flex: 1,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              background: 'linear-gradient(135deg, rgba(0,188,212,0.2) 0%, rgba(255,64,129,0.2) 50%, rgba(0,188,212,0.2) 100%)',
+              position: 'relative',
+              overflow: 'hidden',
+              '&::before': {
+                content: '""',
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                right: 0,
+                bottom: 0,
+                background: 'radial-gradient(circle at 50% 50%, rgba(255,255,255,0.9) 0%, rgba(255,255,255,0.6) 100%)',
+                zIndex: 0
+              }
+            }}
+          >
+            <FunBackground />
+            <Typography
+              variant="h4"
+              sx={{
+                fontWeight: 600,
+                color: 'text.primary',
+                textAlign: 'center',
+                position: 'relative',
+                zIndex: 1,
+                px: 2,
+                textShadow: '0 2px 4px rgba(0,0,0,0.1)'
+              }}
+            >
+              Connecting to host...
+            </Typography>
+          </Box>
         )}
       </Box>
     </Box>

--- a/src/games/farsketched/__tests__/reducer.test.ts
+++ b/src/games/farsketched/__tests__/reducer.test.ts
@@ -3,13 +3,7 @@ import {
   MessageType, 
   GameStage, 
   GameMessage,
-  PingMessage,
   SetPlayerInfoMessage,
-  ConnectionRequestMessage,
-  ConnectionAcceptedMessage,
-  ConnectionRejectedMessage,
-  PongMessage,
-  DisconnectMessage,
   PlayerJoinedMessage,
   RequestStartGameMessage,
   GameStartingMessage,
@@ -60,11 +54,6 @@ const sendSelfMessage = (msg: GameMessage) => {
 };
 
 describe('farsketchedReducer', () => {
-  it('should return initial state when no state is provided', () => {
-    const result = farsketchedReducer(undefined, createMessage<PingMessage>(MessageType.PING, {}), sendSelfMessage);
-    expect(result).toEqual(initialState);
-  });
-
   it('should handle SET_PLAYER_INFO message', () => {
     const message = createMessage<SetPlayerInfoMessage>(MessageType.SET_PLAYER_INFO, {
       playerId: 'player1',
@@ -84,23 +73,6 @@ describe('farsketchedReducer', () => {
       lastSeen: expect.any(Number)
     });
   });
-
-  it('should handle connection messages without state changes', () => {
-    const connectionMessages = [
-      createMessage<ConnectionRequestMessage>(MessageType.CONNECTION_REQUEST, { playerId: 'test', room: 'test' }),
-      createMessage<ConnectionAcceptedMessage>(MessageType.CONNECTION_ACCEPTED, { gameState: initialState, yourPlayerId: 'test' }),
-      createMessage<ConnectionRejectedMessage>(MessageType.CONNECTION_REJECTED, { reason: 'test' }),
-      createMessage<PingMessage>(MessageType.PING, {}),
-      createMessage<PongMessage>(MessageType.PONG, {}),
-      createMessage<DisconnectMessage>(MessageType.DISCONNECT, { playerId: 'test' })
-    ];
-
-    connectionMessages.forEach(message => {
-      const result = farsketchedReducer(initialState, message, sendSelfMessage);
-      expect(result).toEqual(initialState);
-    });
-  });
-
 
   it('should handle start game', () => {
     const lobbyMessages = [
@@ -202,11 +174,6 @@ describe('farsketchedReducer', () => {
       const result = farsketchedReducer(initialState, message, sendSelfMessage);
       expect(result).toEqual(initialState);
     });
-  });
-
-  it('should handle unknown message types by returning current state', () => {
-    const result = farsketchedReducer(initialState, createMessage<PingMessage>('UNKNOWN_TYPE' as MessageType, {}), sendSelfMessage);
-    expect(result).toEqual(initialState);
   });
 
   it('should only store the first guess from a player and ignore subsequent guesses', () => {

--- a/src/games/farsketched/host/Host.tsx
+++ b/src/games/farsketched/host/Host.tsx
@@ -17,7 +17,7 @@ const gameConfig: GameConfig = {
   promptTimerSeconds: 45,
   foolingTimerSeconds: 45,
   guessingTimerSeconds: 20,
-  scoringDisplaySeconds: 10,
+  scoringDisplaySeconds: 20,
   room: ''
 };
 

--- a/src/games/farsketched/host/ScoringStage.tsx
+++ b/src/games/farsketched/host/ScoringStage.tsx
@@ -300,6 +300,7 @@ export function ScoringStage({ gameState }: { gameState: GameState }) {
                 maxWidth: '100%',
                 maxHeight: '100%',
                 objectFit: 'contain',
+                borderRadius: 2,
               }}
             />
           </Box>
@@ -383,6 +384,7 @@ export function ScoringStage({ gameState }: { gameState: GameState }) {
                       }}
                     >
                       {prompt.text}
+                      {showRealFake && <><br />- {creator.name}</>}
                     </Typography>
                     <Stack direction="row" spacing={-1} alignItems="center" sx={{ minWidth: 48 }}>
                       {guessers.length ? (

--- a/src/games/farsketched/reducer.ts
+++ b/src/games/farsketched/reducer.ts
@@ -163,15 +163,6 @@ export function farsketchedReducer(
   sendSelfMessage: (msg: GameMessage) => void
 ): GameState {
   switch (message.type) {
-    // Connection messages
-    case MessageType.CONNECTION_REQUEST:
-    case MessageType.CONNECTION_ACCEPTED:
-    case MessageType.CONNECTION_REJECTED:
-    case MessageType.PING:
-    case MessageType.PONG:
-    case MessageType.DISCONNECT:
-      return state;
-
     // Lobby messages
     case MessageType.SET_PLAYER_INFO: {
       const existingPlayer = state.players[message.playerId];

--- a/src/games/farsketched/types.ts
+++ b/src/games/farsketched/types.ts
@@ -134,14 +134,6 @@ export interface Player {
    * Types of messages that can be sent between host and clients
    */
   export enum MessageType {
-    // Connection messages
-    CONNECTION_REQUEST = 'connection_request',
-    CONNECTION_ACCEPTED = 'connection_accepted',
-    CONNECTION_REJECTED = 'connection_rejected',
-    PING = 'ping',
-    PONG = 'pong',
-    DISCONNECT = 'disconnect',
-    
     // Lobby messages
     SET_PLAYER_INFO = 'set_player_info',
     PLAYER_JOINED = 'player_joined',
@@ -171,56 +163,6 @@ export interface Player {
     type: MessageType;
     timestamp: number;
     messageId: string;    // Unique ID to prevent duplicate processing
-  }
-  
-  // ==================== Connection Messages ====================
-  
-  /**
-   * Client requests to join a game with a player ID
-   */
-  export interface ConnectionRequestMessage extends BaseMessage {
-    type: MessageType.CONNECTION_REQUEST;
-    playerId: string;     // UUID stored in local storage
-    room: string;     // Room code from URL parameter
-  }
-  
-  /**
-   * Host accepts a connection request
-   */
-  export interface ConnectionAcceptedMessage extends BaseMessage {
-    type: MessageType.CONNECTION_ACCEPTED;
-    gameState: GameState; // Current game state
-    yourPlayerId: string; // Confirming the player's ID
-  }
-  
-  /**
-   * Host rejects a connection request
-   */
-  export interface ConnectionRejectedMessage extends BaseMessage {
-    type: MessageType.CONNECTION_REJECTED;
-    reason: string;       // Why the connection was rejected
-  }
-  
-  /**
-   * Keep-alive ping message
-   */
-  export interface PingMessage extends BaseMessage {
-    type: MessageType.PING;
-  }
-  
-  /**
-   * Response to ping
-   */
-  export interface PongMessage extends BaseMessage {
-    type: MessageType.PONG;
-  }
-  
-  /**
-   * Notification that a client is disconnecting
-   */
-  export interface DisconnectMessage extends BaseMessage {
-    type: MessageType.DISCONNECT;
-    playerId: string;
   }
   
   // ==================== Lobby Messages ====================
@@ -352,12 +294,6 @@ export interface Player {
   // ==================== Union Type for All Messages ====================
   
   export type GameMessage =
-    | ConnectionRequestMessage
-    | ConnectionAcceptedMessage
-    | ConnectionRejectedMessage
-    | PingMessage
-    | PongMessage
-    | DisconnectMessage
     | SetPlayerInfoMessage
     | PlayerJoinedMessage
     | PlayerLeftMessage

--- a/src/games/flibbertigibbet/__tests__/reducer.test.ts
+++ b/src/games/flibbertigibbet/__tests__/reducer.test.ts
@@ -3,13 +3,7 @@ import {
   MessageType, 
   GameStage, 
   GameMessage,
-  PingMessage,
   SetPlayerInfoMessage,
-  ConnectionRequestMessage,
-  ConnectionAcceptedMessage,
-  ConnectionRejectedMessage,
-  PongMessage,
-  DisconnectMessage,
   PlayerJoinedMessage,
   RequestStartGameMessage,
   GameStartingMessage,
@@ -78,11 +72,6 @@ const sendSelfMessage = (msg: GameMessage) => {
 };
 
 describe('flibbertigibbetReducer', () => {
-  it('should return initial state when no state is provided', () => {
-    const result = flibbertigibbetReducer(DEFAULT_CONFIG, undefined, createMessage<PingMessage>(MessageType.PING, {}), sendSelfMessage);
-    expect(result).toEqual(initialState);
-  });
-
   it('should handle SET_PLAYER_INFO message', () => {
     const message = createMessage<SetPlayerInfoMessage>(MessageType.SET_PLAYER_INFO, {
       playerId: 'player1',
@@ -100,22 +89,6 @@ describe('flibbertigibbetReducer', () => {
       connected: true,
       points: 0,
       lastSeen: expect.any(Number)
-    });
-  });
-
-  it('should handle connection messages without state changes', () => {
-    const connectionMessages = [
-      createMessage<ConnectionRequestMessage>(MessageType.CONNECTION_REQUEST, { playerId: 'test', room: 'test' }),
-      createMessage<ConnectionAcceptedMessage>(MessageType.CONNECTION_ACCEPTED, { gameState: initialState, yourPlayerId: 'test' }),
-      createMessage<ConnectionRejectedMessage>(MessageType.CONNECTION_REJECTED, { reason: 'test' }),
-      createMessage<PingMessage>(MessageType.PING, {}),
-      createMessage<PongMessage>(MessageType.PONG, {}),
-      createMessage<DisconnectMessage>(MessageType.DISCONNECT, { playerId: 'test' })
-    ];
-
-    connectionMessages.forEach(message => {
-      const result = flibbertigibbetReducer(DEFAULT_CONFIG, initialState, message, sendSelfMessage);
-      expect(result).toEqual(initialState);
     });
   });
 
@@ -219,11 +192,6 @@ describe('flibbertigibbetReducer', () => {
       const result = flibbertigibbetReducer(DEFAULT_CONFIG, initialState, message, sendSelfMessage);
       expect(result).toEqual(initialState);
     });
-  });
-
-  it('should handle unknown message types by returning current state', () => {
-    const result = flibbertigibbetReducer(DEFAULT_CONFIG, initialState, createMessage<PingMessage>('UNKNOWN_TYPE' as MessageType, {}), sendSelfMessage);
-    expect(result).toEqual(initialState);
   });
 
   it('should only store the first guess from a player and ignore subsequent guesses', () => {

--- a/src/games/flibbertigibbet/host/Host.tsx
+++ b/src/games/flibbertigibbet/host/Host.tsx
@@ -18,7 +18,7 @@ const DEFAULT_CONFIG: GameConfig = {
   promptTimerSeconds: 45,
   foolingTimerSeconds: 45,
   guessingTimerSeconds: 20,
-  scoringDisplaySeconds: 10,
+  scoringDisplaySeconds: 20,
   room: '',
   instructions: {ai: '', human: ''}
 };
@@ -43,6 +43,8 @@ export function HostContent() {
   */
 
   // TODO: move this out; it will be used by all games
+  // Idea: We can useHostGameState<GameState>(reducerFunction) and let the hostGameStateProvider call the reducer function
+  // Then the provider can handle all the peer messages!
   useEffect(() => {
     messages.forEach(msg => {
       try {

--- a/src/games/flibbertigibbet/reducer.ts
+++ b/src/games/flibbertigibbet/reducer.ts
@@ -152,15 +152,6 @@ export function flibbertigibbetReducer(
   sendSelfMessage: (msg: GameMessage) => void
 ): GameState {
   switch (message.type) {
-    // Connection messages
-    case MessageType.CONNECTION_REQUEST:
-    case MessageType.CONNECTION_ACCEPTED:
-    case MessageType.CONNECTION_REJECTED:
-    case MessageType.PING:
-    case MessageType.PONG:
-    case MessageType.DISCONNECT:
-      return state;
-
     // Lobby messages
     case MessageType.SET_PLAYER_INFO: {
       const existingPlayer = state.players[message.playerId];

--- a/src/games/flibbertigibbet/types.ts
+++ b/src/games/flibbertigibbet/types.ts
@@ -137,14 +137,6 @@ export interface Player {
    * Types of messages that can be sent between host and clients
    */
   export enum MessageType {
-    // Connection messages
-    CONNECTION_REQUEST = 'connection_request',
-    CONNECTION_ACCEPTED = 'connection_accepted',
-    CONNECTION_REJECTED = 'connection_rejected',
-    PING = 'ping',
-    PONG = 'pong',
-    DISCONNECT = 'disconnect',
-    
     // Lobby messages
     SET_PLAYER_INFO = 'set_player_info',
     PLAYER_JOINED = 'player_joined',
@@ -174,56 +166,6 @@ export interface Player {
     type: MessageType;
     timestamp: number;
     messageId: string;    // Unique ID to prevent duplicate processing
-  }
-  
-  // ==================== Connection Messages ====================
-  
-  /**
-   * Client requests to join a game with a player ID
-   */
-  export interface ConnectionRequestMessage extends BaseMessage {
-    type: MessageType.CONNECTION_REQUEST;
-    playerId: string;     // UUID stored in local storage
-    room: string;     // Room code from URL parameter
-  }
-  
-  /**
-   * Host accepts a connection request
-   */
-  export interface ConnectionAcceptedMessage extends BaseMessage {
-    type: MessageType.CONNECTION_ACCEPTED;
-    gameState: GameState; // Current game state
-    yourPlayerId: string; // Confirming the player's ID
-  }
-  
-  /**
-   * Host rejects a connection request
-   */
-  export interface ConnectionRejectedMessage extends BaseMessage {
-    type: MessageType.CONNECTION_REJECTED;
-    reason: string;       // Why the connection was rejected
-  }
-  
-  /**
-   * Keep-alive ping message
-   */
-  export interface PingMessage extends BaseMessage {
-    type: MessageType.PING;
-  }
-  
-  /**
-   * Response to ping
-   */
-  export interface PongMessage extends BaseMessage {
-    type: MessageType.PONG;
-  }
-  
-  /**
-   * Notification that a client is disconnecting
-   */
-  export interface DisconnectMessage extends BaseMessage {
-    type: MessageType.DISCONNECT;
-    playerId: string;
   }
   
   // ==================== Lobby Messages ====================
@@ -355,12 +297,6 @@ export interface Player {
   // ==================== Union Type for All Messages ====================
   
   export type GameMessage =
-    | ConnectionRequestMessage
-    | ConnectionAcceptedMessage
-    | ConnectionRejectedMessage
-    | PingMessage
-    | PongMessage
-    | DisconnectMessage
     | SetPlayerInfoMessage
     | PlayerJoinedMessage
     | PlayerLeftMessage


### PR DESCRIPTION
We don't use the connection messages (the peer context and game state provider handle connections for us). We might want to allow for "player left" messages to get generated on disconnect, tbd.